### PR TITLE
Fix git command for file list

### DIFF
--- a/miq.gemspec
+++ b/miq.gemspec
@@ -8,7 +8,7 @@ spec = Gem::Specification.new do |s|
   s.homepage = 'http://juliancheal.co.uk'
   s.platform = Gem::Platform::RUBY
   s.summary = 'A description of your project'
-  s.files = `git ls-files`.split("")
+  s.files = `git ls-files -z`.split("\x0")
 
   s.require_paths << 'lib'
   s.bindir = 'bin'


### PR DESCRIPTION
Your git command for the file listing is busted. This PR fixes it.

Partially addresses https://github.com/juliancheal/ManageIQ-Cli/issues/3
