### PR TITLE
Add rspec as a development dependency

### DIFF
--- a/miq.gemspec
+++ b/miq.gemspec
@@ -14,6 +14,7 @@ spec = Gem::Specification.new do |s|
   s.bindir = 'bin'
   s.executables << 'miq'
   s.add_development_dependency('rake')
+  s.add_development_dependency('rspec', '~>3')
 
   s.add_runtime_dependency('gli','2.17.0')
   s.add_runtime_dependency('manageiq-api-client', '~> 0.2.0')


### PR DESCRIPTION
This PR updates the gemspec by adding rspec 3.x as a development dependency.

Fixes the other issue mentioned in https://github.com/juliancheal/ManageIQ-Cli/issues/3